### PR TITLE
updated entry page tests

### DIFF
--- a/tests/entry_page_test.js
+++ b/tests/entry_page_test.js
@@ -1,21 +1,20 @@
 const utils = require('../utils/utils');
 
 Feature('entry_page');
-Scenario('Verify only entry point confirmation when both experiments match', async ({ I }) => {
-    //Act
-    I.amOnPage('/index.html');
+
+async function arrangeTest(I, page) {
+    I.amOnPage(page);
     I.wait(2);
 
     let confirmations = await I.executeScript(async () => {
         let confirmationsArray = [];
 
-        if(evolv.context.remoteContext.experiments.confirmations){
+        if (evolv.context.remoteContext.experiments.confirmations) {
             evolv.context.remoteContext.experiments.confirmations.forEach(element => {
                 confirmationsArray.push(element.cid);
             })
             return confirmationsArray;
-        }
-        else {
+        } else {
             throw new Error("No confirmations on this page!");
         };
     });
@@ -29,59 +28,96 @@ Scenario('Verify only entry point confirmation when both experiments match', asy
     let experimentsConfig = await utils.getConfiguration();
     const allActiveKeysEntryPointInfo = await utils.getEntryPoints(activeKeys, experimentsConfig);
 
-    //Assert
-    I.assertTrue(confirmations.length > 0);
-    allActiveKeysEntryPointInfo.forEach(element => {
-        confirmations.forEach(confirmation => {
-            if(element.isEntryPoint) {
-                I.assertTrue(confirmation.indexOf(element.id) > -1);
-            }else{
-                I.assertTrue(confirmation.indexOf(element.id) === -1);
+    const countOfEntryPoints = allActiveKeysEntryPointInfo.filter(key => key.isEntryPoint).length;
+    const countOfConfirmations = confirmations.length;
+
+    console.log(`Entry points: ${countOfEntryPoints}`);
+    console.log(`Confirmations: ${countOfConfirmations}`);
+
+    const experimentDetails = {
+        confirmations: confirmations,
+        allActiveKeysEntryPointInfo: allActiveKeysEntryPointInfo,
+        countOfEntryPoints: countOfEntryPoints,
+        countOfConfirmations: countOfConfirmations
+    }
+
+    return experimentDetails;
+}
+
+Scenario('Verify confirmation when both experiments match the context and the first has entry point equal to true', async ({ I }) => {
+    // Act
+    const page = '/index.html';
+    const exp = await arrangeTest(I, page);
+
+    // Assert
+    I.assertTrue(exp.countOfEntryPoints === exp.countOfConfirmations);
+    I.assertTrue(exp.countOfConfirmations > 0);
+
+    exp.confirmations.forEach(confirmation => {
+        exp.allActiveKeysEntryPointInfo.find(key => {
+            if (key.isEntryPoint) {
+                I.assertTrue(confirmation.indexOf(key.id) > -1);
+            } else {
+                I.assertTrue(confirmation.indexOf(key.id) === -1);
             }
         })
-    });
-});
-
-Scenario('Verify no confirmations when none of experiment matching', async ({ I }) => {
-    //Act
-    I.amOnPage('/');
-    I.wait(2);
-    let confirmations = await I.executeScript(async () => {
-        let confirmationsArray = [];
-
-        if(evolv.context.remoteContext.experiments.confirmations){
-
-            evolv.context.remoteContext.experiments.confirmations.forEach(element => {
-                confirmationsArray.push(element.cid);
-            })
-            return confirmationsArray;
-        }
-        else {
-            return [];
-        };
-    });
-
-    let activeKeys = await I.executeScript(async () => {
-        let keys = await evolv.client.getActiveKeys();
-        let filteredKeys = keys.current.filter(key => key.split('.').length < 3);
-        return filteredKeys.map(key => key.split('.')[1]);
     })
-
-    let experimentsConfig = await utils.getConfiguration();
-
-    const entryPoints = await utils.getEntryPoints(activeKeys, experimentsConfig);
-
-    //Assert
-    entryPoints.forEach(element => {
-        if(element.isEntryPoint){
-            I.assertContain(confirmations[entryPoints.indexOf(element)], element.id);
-        }else{
-            I.assertNotContain(confirmations[entryPoints.indexOf(element)], element.id);
-        }
-    });
-
-    I.assertEqual(confirmations.length, 0);
-    entryPoints.forEach(element => {
-        I.assertEqual(element.isEntryPoint, false);
-    });
 });
+
+// Scenario('Verify confirmation when both experiments match the context and the second has entry point equal to true', async ({ I }) => {
+//     //Act
+//     const page = '/index.html';
+//     await arrangeTest(I, page);
+//
+// });
+
+// Scenario('Verify confirmation when both experiments match the context and both have entry point equal to true', async ({ I }) => {
+//     //Act
+//     const page = '/index.html';
+//     await doTest(I, page);
+//     I.assertTrue(countOfConfirmations > 0);
+// });
+//
+// Scenario('Verify no confirmations when none of experiment matching', async ({ I }) => {
+//     //Act
+//     I.amOnPage('/');
+//     I.wait(2);
+//     let confirmations = await I.executeScript(async () => {
+//         let confirmationsArray = [];
+//
+//         if(evolv.context.remoteContext.experiments.confirmations){
+//
+//             evolv.context.remoteContext.experiments.confirmations.forEach(element => {
+//                 confirmationsArray.push(element.cid);
+//             })
+//             return confirmationsArray;
+//         }
+//         else {
+//             return [];
+//         };
+//     });
+//
+//     let activeKeys = await I.executeScript(async () => {
+//         let keys = await evolv.client.getActiveKeys();
+//         let filteredKeys = keys.current.filter(key => key.split('.').length < 3);
+//         return filteredKeys.map(key => key.split('.')[1]);
+//     })
+//
+//     let experimentsConfig = await utils.getConfiguration();
+//
+//     const entryPoints = await utils.getEntryPoints(activeKeys, experimentsConfig);
+//
+//     //Assert
+//     entryPoints.forEach(element => {
+//         if(element.isEntryPoint){
+//             I.assertContain(confirmations[entryPoints.indexOf(element)], element.id);
+//         }else{
+//             I.assertNotContain(confirmations[entryPoints.indexOf(element)], element.id);
+//         }
+//     });
+//
+//     I.assertEqual(confirmations.length, 0);
+//     entryPoints.forEach(element => {
+//         I.assertEqual(element.isEntryPoint, false);
+//     });
+// });

--- a/tests/entry_page_test.js
+++ b/tests/entry_page_test.js
@@ -1,15 +1,15 @@
 const utils = require('../utils/utils');
 
 Feature('entry_page');
-Scenario('Verify confirmations when both experiments matching', async ({ I }) => {
+Scenario('Verify only entry point confirmation when both experiments match', async ({ I }) => {
     //Act
     I.amOnPage('/index.html');
     I.wait(2);
+
     let confirmations = await I.executeScript(async () => {
         let confirmationsArray = [];
-       
-        if(evolv.context.remoteContext.experiments.confirmations){
 
+        if(evolv.context.remoteContext.experiments.confirmations){
             evolv.context.remoteContext.experiments.confirmations.forEach(element => {
                 confirmationsArray.push(element.cid);
             })
@@ -27,88 +27,18 @@ Scenario('Verify confirmations when both experiments matching', async ({ I }) =>
     })
 
     let experimentsConfig = await utils.getConfiguration();
- 
-    const entryPoints = await utils.getEntryPoints(activeKeys, experimentsConfig);
-   
+    const allActiveKeysEntryPointInfo = await utils.getEntryPoints(activeKeys, experimentsConfig);
+
     //Assert
-    entryPoints.forEach(element => {
-        if(element.isEntryPoint){
-            I.assertContain(confirmations[entryPoints.indexOf(element)], element.id);
-        }else{
-            I.assertNotContain(confirmations[entryPoints.indexOf(element)], element.id);
-        }
-    });
-});
-
-Scenario('Verify no confirmations when first experiment (non entry page) matching', async ({ I }) => {
-   //Act
-   I.amOnPage('/clone.html');
-   I.wait(2);
-   let activeKeys = await I.executeScript(async () => {
-       let keys = await evolv.client.getActiveKeys();
-       let filteredKeys = keys.current.filter(key => key.split('.').length < 3);
-       return filteredKeys.map(key => key.split('.')[1]);
-   })
-   let experimentsConfig = await utils.getConfiguration();
-   let confirmations = await I.executeScript(async () => {
-       let confirmationsArray = [];
-      
-       if(evolv.context.remoteContext.experiments.confirmations){
-
-           evolv.context.remoteContext.experiments.confirmations.forEach(element => {
-               confirmationsArray.push(element.cid);
-           })
-           return confirmationsArray;
-       }
-       else {
-           return [];
-       };
-   });
-   const entryPoints = await utils.getEntryPoints(activeKeys, experimentsConfig);
-
-   //Assert
-   I.assertEqual(confirmations.length, 0);
-   entryPoints.forEach(element => {
-        I.assertEqual(element.isEntryPoint, false);
-   });
-});
-
-Scenario('Verify confirmations when second experiment (entry page) matching', async ({ I }) => {
-    //Act
-    I.amOnPage('/clone1.html');
-    I.wait(2);
-    let confirmations = await I.executeScript(async () => {
-        let confirmationsArray = [];
-       
-        if(evolv.context.remoteContext.experiments.confirmations){
-
-            evolv.context.remoteContext.experiments.confirmations.forEach(element => {
-                confirmationsArray.push(element.cid);
-            })
-            return confirmationsArray;
-        }
-        else {
-            return [];
-        };
-    });
-
-    let activeKeys = await I.executeScript(async () => {
-        let keys = await evolv.client.getActiveKeys();
-        let filteredKeys = keys.current.filter(key => key.split('.').length < 3);
-        return filteredKeys.map(key => key.split('.')[1]);
-    })
-
-    let experimentsConfig = await utils.getConfiguration();
- 
-    const entryPoints = await utils.getEntryPoints(activeKeys, experimentsConfig);
-   
-    //Assert
-    entryPoints.forEach(element => {
-        if(element.isEntryPoint){
-            I.assertContain(confirmations[entryPoints.indexOf(element)], element.id);
-        }else{
-            I.assertNotContain(confirmations[entryPoints.indexOf(element)], element.id);
-        }
+    I.assertTrue(confirmations.length > 0);
+    allActiveKeysEntryPointInfo.forEach(element => {
+        confirmations.forEach(confirmation => {
+            if(element.isEntryPoint) {
+                I.assertTrue(confirmation.indexOf(element.id) > -1);
+            }else{
+                I.assertTrue(confirmation.indexOf(element.id) === -1);
+            }
+        })
     });
 });
 
@@ -118,7 +48,7 @@ Scenario('Verify no confirmations when none of experiment matching', async ({ I 
     I.wait(2);
     let confirmations = await I.executeScript(async () => {
         let confirmationsArray = [];
-       
+
         if(evolv.context.remoteContext.experiments.confirmations){
 
             evolv.context.remoteContext.experiments.confirmations.forEach(element => {
@@ -138,9 +68,9 @@ Scenario('Verify no confirmations when none of experiment matching', async ({ I 
     })
 
     let experimentsConfig = await utils.getConfiguration();
- 
+
     const entryPoints = await utils.getEntryPoints(activeKeys, experimentsConfig);
-   
+
     //Assert
     entryPoints.forEach(element => {
         if(element.isEntryPoint){
@@ -152,6 +82,6 @@ Scenario('Verify no confirmations when none of experiment matching', async ({ I 
 
     I.assertEqual(confirmations.length, 0);
     entryPoints.forEach(element => {
-         I.assertEqual(element.isEntryPoint, false);
+        I.assertEqual(element.isEntryPoint, false);
     });
 });


### PR DESCRIPTION
I updated the first test to properly check for entry point true and false, allowing for 'undefined'. I also checked confirmations.length to make sure there's at least one confirmation.

The two middle tests were redundant, so I removed them. Both of these cases are handled by the first test.
- Verify no confirmations when first experiment (non entry page) matching
- Verify confirmations when second experiment (entry page) matching

There's no sense of which experiment is first or second. The way I looked at it was to make sure we have confirmations for experiments where entry point is true, and didn't have confirmations if entry point is false.

I checked the first test against `dev` and `next`. As expected, the test fails on `next`.
![entry-page-next](https://user-images.githubusercontent.com/78709720/142974272-c4e8de4b-0b72-4876-8cab-4c429f719209.png)
![entry-page-dev](https://user-images.githubusercontent.com/78709720/142974282-357549a5-9d5e-4c31-a1b9-8e3da3e8f27e.png)


