### PR TITLE
chore: refactored scenarios for readability

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run e2e Tests
         run: |
           npm install
-          npm run test:dev
+          npm run test
         env:
           HOST_URL: "http://localhost:9090/"
       - name: Slack Notification (failure)

--- a/tests/entry_page_test.js
+++ b/tests/entry_page_test.js
@@ -15,30 +15,30 @@ const logExperimentDetails = (
 }
 
 const validateEntryPoints = (allActiveKeysEntryPointInfo, entryPointValue) => {
-    let isValid;
     allActiveKeysEntryPointInfo.forEach(key => {
-        if (key.isEntryPoint === entryPointValue) {
-            isValid === false ? isValid = false : isValid = true;
-        } else {
-            isValid = false;
+        if (key.isEntryPoint !== entryPointValue) {
+            return false
         }
     })
-    return isValid;
+    return true;
 }
 
 const checkOnlyEntryPointConfirmations = (confirmations, allActiveKeysEntryPointInfo) => {
-    let validChecks = 0;
     confirmations.forEach(confirmation => {
         allActiveKeysEntryPointInfo.find(key => {
             if (key.isEntryPoint) {
-                confirmation.indexOf(key.id) > -1 ? validChecks += 1 : validChecks -= 1;
+                if (confirmation.indexOf(key.id) === -1) {
+                    return false
+                }
             } else {
-                confirmation.indexOf(key.id) === -1 ? validChecks += 1 : validChecks -= 1;
+                if (confirmation.indexOf(key.id) > -1) {
+                    return false
+                }
             }
         })
     })
 
-    return validChecks === allActiveKeysEntryPointInfo.length;
+    return true;
 }
 
 async function arrangeTest(I, page) {


### PR DESCRIPTION
I created new functions with easy to read names. All assertions remain inside the scenarios.

All tests pass locally running `npm run test`.